### PR TITLE
 implementar boton para subir y actualizar foto de perfil de organizaciones

### DIFF
--- a/frontend/src/app/core/services/organization-profile.service.ts
+++ b/frontend/src/app/core/services/organization-profile.service.ts
@@ -255,20 +255,15 @@ export class OrganizationProfileService {
   /**
    * Subir logo de la organización
    */
-  uploadLogo(id: string, file: File): Observable<{ logoUrl: string }> {
+  uploadLogo(id: string, file: File): Observable<any> {
     const formData = new FormData();
-    formData.append('logo', file);
+    formData.append('profilePhoto', file);
 
-    return this.http.post<{ logoUrl: string }>(`${this.apiUrl}/${id}/upload-logo`, formData).pipe(
+    return this.http.post<any>(`${environment.apiBaseUrl}/update-me/profile-photo`, formData).pipe(
       tap(response => {
-        const currentProfile = this.profileSubject.value;
-        if (currentProfile) {
-          this.profileSubject.next({
-            ...currentProfile,
-            logo: response.logoUrl
-          });
-          this.lastUpdateSubject.next(new Date());
-        }
+        // Recargar el perfil completo después de subir la imagen
+        this.getMyOrganizationProfile().subscribe();
+        this.lastUpdateSubject.next(new Date());
       }),
       catchError(error => {
         console.error('Error al subir logo:', error);
@@ -279,21 +274,17 @@ export class OrganizationProfileService {
 
   /**
    * Subir imagen de portada de la organización
+   * Nota: El backend actual solo soporta profilePhoto, esta funcionalidad será implementada en el futuro
    */
-  uploadCoverImage(id: string, file: File): Observable<{ coverImageUrl: string }> {
+  uploadCoverImage(id: string, file: File): Observable<any> {
     const formData = new FormData();
-    formData.append('coverImage', file);
+    formData.append('profilePhoto', file);
 
-    return this.http.post<{ coverImageUrl: string }>(`${this.apiUrl}/${id}/upload-cover`, formData).pipe(
+    return this.http.post<any>(`${environment.apiBaseUrl}/update-me/profile-photo`, formData).pipe(
       tap(response => {
-        const currentProfile = this.profileSubject.value;
-        if (currentProfile) {
-          this.profileSubject.next({
-            ...currentProfile,
-            coverImage: response.coverImageUrl
-          });
-          this.lastUpdateSubject.next(new Date());
-        }
+        // Recargar el perfil completo después de subir la imagen
+        this.getMyOrganizationProfile().subscribe();
+        this.lastUpdateSubject.next(new Date());
       }),
       catchError(error => {
         console.error('Error al subir imagen de portada:', error);

--- a/frontend/src/app/features/organization/profile/organization-profile.component.html
+++ b/frontend/src/app/features/organization/profile/organization-profile.component.html
@@ -70,18 +70,23 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"/>
                 </svg>
               </button>
-              <!-- Botón de Guardar Logo -->
-              <button *ngIf="selectedLogo && !saving"
-                      (click)="uploadLogo()"
-                      class="absolute -bottom-2 -right-2 px-3 py-1 bg-green-500 text-white rounded-full shadow-lg hover:bg-green-600 text-xs font-medium flex items-center"
-                      title="Guardar logo">
-                <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            </div>
+            
+            <!-- Botón de Guardar Logo -->
+            <div *ngIf="selectedLogo && !saving" class="mb-2">
+              <button (click)="uploadLogo()"
+                      class="px-4 py-2 bg-green-500 text-white rounded-lg shadow-lg hover:bg-green-600 font-medium flex items-center transition-all transform hover:scale-105">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
                 </svg>
-                Guardar
+                Guardar Foto
               </button>
-              <div *ngIf="saving" class="absolute -bottom-2 -right-2 px-3 py-1 bg-gray-400 text-white rounded-full shadow-lg text-xs font-medium flex items-center">
-                <svg class="animate-spin h-3 w-3 mr-1" fill="none" viewBox="0 0 24 24">
+            </div>
+            
+            <!-- Indicador de Subiendo -->
+            <div *ngIf="saving" class="mb-2">
+              <div class="px-4 py-2 bg-gray-400 text-white rounded-lg shadow-lg font-medium flex items-center">
+                <svg class="animate-spin h-5 w-5 mr-2" fill="none" viewBox="0 0 24 24">
                   <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                   <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                 </svg>

--- a/frontend/src/app/features/organization/profile/organization-profile.component.ts
+++ b/frontend/src/app/features/organization/profile/organization-profile.component.ts
@@ -262,15 +262,10 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
     this.clearMessages();
     
     this.profileService.uploadLogo(this.organizationId, this.selectedLogo).subscribe({
-      next: (updatedProfile) => {
+      next: (response) => {
         this.successMessage = '✓ Logo actualizado exitosamente';
         this.selectedLogo = null;
         this.saving = false;
-        
-        // Actualizar el preview con la nueva imagen del servidor
-        if (updatedProfile.logoUrl) {
-          this.logoPreview = updatedProfile.logoUrl;
-        }
         
         // Recargar el perfil completo
         this.loadProfile();
@@ -279,7 +274,7 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
         setTimeout(() => this.successMessage = '', 3000);
       },
       error: (error) => {
-        this.errorMessage = 'Error al subir el logo. Por favor, intenta de nuevo.';
+        this.errorMessage = error.error?.message || 'Error al subir el logo. Por favor, intenta de nuevo.';
         this.saving = false;
         console.error('Error uploading logo:', error);
       }
@@ -293,15 +288,10 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
     this.clearMessages();
     
     this.profileService.uploadCoverImage(this.organizationId, this.selectedCover).subscribe({
-      next: (updatedProfile) => {
+      next: (response) => {
         this.successMessage = '✓ Imagen de portada actualizada exitosamente';
         this.selectedCover = null;
         this.saving = false;
-        
-        // Actualizar el preview con la nueva imagen del servidor
-        if (updatedProfile.coverImageUrl) {
-          this.coverPreview = updatedProfile.coverImageUrl;
-        }
         
         // Recargar el perfil completo
         this.loadProfile();
@@ -310,7 +300,7 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
         setTimeout(() => this.successMessage = '', 3000);
       },
       error: (error) => {
-        this.errorMessage = 'Error al subir la imagen. Por favor, intenta de nuevo.';
+        this.errorMessage = error.error?.message || 'Error al subir la imagen. Por favor, intenta de nuevo.';
         this.saving = false;
         console.error('Error uploading cover:', error);
       }


### PR DESCRIPTION
## descripcion
Implementación de la funcionalidad para subir y actualizar fotos de perfil de organizaciones, corrigiendo el endpoint de subida a /auth/update-me/profile-photo y el campo FormData a 'profilePhoto' para coincidir con el backend. Se mejoró la UI reubicando el botón "Guardar Foto" entre el logo y el nombre de la organización, con visibilidad condicional que solo aparece al seleccionar una imagen, validaciones de tipo y tamaño (máx 1MB), indicador de carga animado durante la subida, y recarga automática del perfil tras una subida exitosa.

 ### fixes #41 

### screenshot
<img width="1864" height="641" alt="image" src="https://github.com/user-attachments/assets/2c52728c-37ae-4208-956b-4380f8b7ac7a" />
