### PR TITLE
 implementar verificación de documento en perfil organization

### DIFF
--- a/frontend/src/app/features/donor/profile/donor-profile.component.ts
+++ b/frontend/src/app/features/donor/profile/donor-profile.component.ts
@@ -383,8 +383,15 @@ export class DonorProfileComponent implements OnInit, OnDestroy {
    */
   checkVerificationStatus(): void {
     const user = this.authService.currentUserValue;
-    this.isDocumentVerified = user?.isDocumentVerified || false;
-    console.log('📋 Estado de verificación:', this.isDocumentVerified);
+    // Revisar en el usuario del AuthService
+    const userVerified = user?.isDocumentVerified || false;
+    // También revisar si el perfil tiene algún campo de verificación
+    // (El profile de donor puede no tener un campo isVerified explícito,
+    // pero lo dejamos por si el backend lo agrega en el futuro)
+    const profileVerified = false; // Donor profile no tiene este campo por ahora
+    
+    this.isDocumentVerified = userVerified || profileVerified;
+    console.log('📋 Estado de verificación (Donor):', this.isDocumentVerified);
   }
 
   /**

--- a/frontend/src/app/features/organization/profile/organization-profile.component.html
+++ b/frontend/src/app/features/organization/profile/organization-profile.component.html
@@ -169,6 +169,106 @@
       </div>
     </div>
 
+    <!-- Sección de Verificación de Organización -->
+    <div *ngIf="!isDocumentVerified" class="bg-yellow-50 border-l-4 border-yellow-400 p-6 mb-6 rounded-lg shadow">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-6 w-6 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+          </svg>
+        </div>
+        <div class="ml-3 flex-1">
+          <h3 class="text-lg font-medium text-yellow-800">
+            Verifica tu organización
+          </h3>
+          <div class="mt-2 text-sm text-yellow-700">
+            <p class="mb-3">
+              Para acceder a todas las funcionalidades de la plataforma, tu organización necesita ser verificada. 
+              Por favor, sube un documento legal de tu organización (RUC, certificado de constitución, registro de ONG, etc.).
+            </p>
+            
+            <div class="bg-white p-4 rounded-md border border-yellow-200">
+              <label class="block text-sm font-medium text-gray-700 mb-2">
+                Documento Legal de la Organización
+              </label>
+              
+              <!-- Preview del documento -->
+              <div *ngIf="documentPreview && documentPreview !== 'pdf'" class="mb-3">
+                <img [src]="documentPreview" alt="Preview" class="max-w-xs h-40 object-contain border border-gray-300 rounded-md">
+              </div>
+              
+              <div *ngIf="documentPreview === 'pdf'" class="mb-3 p-4 bg-gray-50 border border-gray-300 rounded-md flex items-center">
+                <svg class="h-12 w-12 text-red-500 mr-3" fill="currentColor" viewBox="0 0 20 20">
+                  <path fill-rule="evenodd" d="M4 4a2 2 0 012-2h4.586A2 2 0 0112 2.586L15.414 6A2 2 0 0116 7.414V16a2 2 0 01-2 2H6a2 2 0 01-2-2V4z" clip-rule="evenodd"/>
+                </svg>
+                <div>
+                  <p class="font-medium text-gray-900">{{ selectedDocument?.name }}</p>
+                  <p class="text-sm text-gray-500">Documento PDF seleccionado</p>
+                </div>
+              </div>
+              
+              <div class="flex items-center space-x-3">
+                <input type="file" 
+                       accept=".jpg,.jpeg,.png,.pdf" 
+                       (change)="onDocumentSelected($event)" 
+                       #documentInput
+                       class="hidden">
+                
+                <button type="button" 
+                        (click)="documentInput.click()"
+                        [disabled]="isUploadingDocument"
+                        class="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed">
+                  <svg class="inline-block w-4 h-4 mr-2 -mt-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"/>
+                  </svg>
+                  Seleccionar Documento
+                </button>
+                
+                <button type="button" 
+                        *ngIf="selectedDocument"
+                        (click)="uploadDocument()"
+                        [disabled]="isUploadingDocument"
+                        class="px-6 py-2 bg-yellow-500 text-white rounded-md text-sm font-medium hover:bg-yellow-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center">
+                  <svg *ngIf="isUploadingDocument" class="animate-spin -ml-1 mr-2 h-4 w-4 text-white" fill="none" viewBox="0 0 24 24">
+                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  {{ isUploadingDocument ? 'Subiendo...' : 'Verificar Organización' }}
+                </button>
+              </div>
+              
+              <p class="mt-2 text-xs text-gray-600">
+                <strong>Formatos aceptados:</strong> JPG, PNG, PDF • <strong>Tamaño máximo:</strong> 5 MB
+              </p>
+              
+              <p *ngIf="selectedDocument" class="mt-2 text-sm text-gray-700">
+                📎 {{ selectedDocument.name }} ({{ (selectedDocument.size / 1024).toFixed(0) }} KB)
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Badge de Verificado -->
+    <div *ngIf="isDocumentVerified" class="bg-green-50 border-l-4 border-green-400 p-4 mb-6 rounded-lg shadow">
+      <div class="flex">
+        <div class="flex-shrink-0">
+          <svg class="h-6 w-6 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"/>
+          </svg>
+        </div>
+        <div class="ml-3">
+          <p class="text-sm font-medium text-green-800">
+            ✓ Organización Verificada
+          </p>
+          <p class="mt-1 text-sm text-green-700">
+            Tu organización ha sido verificada exitosamente. Ahora tienes acceso completo a todas las funcionalidades de la plataforma.
+          </p>
+        </div>
+      </div>
+    </div>
+
     <!-- Messages -->
     <div *ngIf="successMessage" class="mb-6 bg-green-50 border border-green-200 text-green-800 px-4 py-3 rounded-lg">
       <div class="flex items-center">

--- a/frontend/src/app/features/organization/profile/organization-profile.component.ts
+++ b/frontend/src/app/features/organization/profile/organization-profile.component.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Subject, takeUntil } from 'rxjs';
 import { OrganizationProfileService, OrganizationProfile, OrganizationActivityLog } from '../../../core/services/organization-profile.service';
 import { AuthService, User } from '../../../core/services/auth.service';
+import { VerificationService } from '../../../core/services/verification.service';
 
 @Component({
   selector: 'app-organization-profile',
@@ -36,6 +37,12 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
   selectedCover: File | null = null;
   coverPreview: string | null = null;
   
+  // Verificación de documento
+  selectedDocument: File | null = null;
+  documentPreview: string | null = null;
+  isUploadingDocument = false;
+  isDocumentVerified = false;
+  
   // Control de visibilidad de contraseñas
   showCurrentPassword = false;
   showNewPassword = false;
@@ -45,7 +52,8 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
     private fb: FormBuilder,
     private route: ActivatedRoute,
     private profileService: OrganizationProfileService,
-    private authService: AuthService
+    private authService: AuthService,
+    private verificationService: VerificationService
   ) {
     this.initializeForms();
   }
@@ -60,6 +68,7 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
     });
     
     this.subscribeToProfileChanges();
+    this.checkVerificationStatus();
   }
 
   ngOnDestroy(): void {
@@ -125,6 +134,8 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
     this.profileService.getMyOrganizationProfile().subscribe({
       next: (profile) => {
         this.populateForm(profile);
+        // Actualizar estado de verificación después de cargar el perfil
+        this.checkVerificationStatus();
       },
       error: (error) => {
         this.errorMessage = 'Error al cargar el perfil. Por favor, intenta de nuevo.';
@@ -436,5 +447,104 @@ export class OrganizationProfileComponent implements OnInit, OnDestroy {
   
   toggleConfirmPasswordVisibility(): void {
     this.showConfirmPassword = !this.showConfirmPassword;
+  }
+
+  // ============ MÉTODOS DE VERIFICACIÓN DE DOCUMENTO ============
+
+  /**
+   * Verificar el estado de verificación de la organización
+   */
+  checkVerificationStatus(): void {
+    const user = this.authService.currentUserValue;
+    // Revisar primero en el usuario del AuthService
+    const userVerified = user?.isDocumentVerified || false;
+    // También revisar en el perfil de la organización
+    const profileVerified = this.profile?.isVerified || false;
+    
+    // Si cualquiera de los dos está verificado, marcar como verificado
+    this.isDocumentVerified = userVerified || profileVerified;
+    
+    console.log('📋 Estado de verificación (Organization):', {
+      userVerified,
+      profileVerified,
+      finalStatus: this.isDocumentVerified
+    });
+  }
+
+  /**
+   * Manejar la selección de documento para verificación
+   */
+  onDocumentSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files[0]) {
+      const file = input.files[0];
+      
+      // Validar el archivo usando el servicio
+      const validation = this.verificationService.validateFile(file);
+      
+      if (!validation.valid) {
+        this.errorMessage = validation.error || 'Archivo inválido';
+        this.selectedDocument = null;
+        this.documentPreview = null;
+        input.value = '';
+        return;
+      }
+      
+      this.selectedDocument = file;
+      this.clearMessages();
+      
+      // Preview del documento (solo para imágenes)
+      if (file.type.startsWith('image/')) {
+        const reader = new FileReader();
+        reader.onload = (e: ProgressEvent<FileReader>) => {
+          this.documentPreview = e.target?.result as string;
+        };
+        reader.readAsDataURL(file);
+      } else {
+        // Para PDFs, mostrar icono genérico
+        this.documentPreview = 'pdf';
+      }
+      
+      console.log('📎 Documento seleccionado (Organization):', file.name);
+    }
+  }
+
+  /**
+   * Subir documento de verificación
+   */
+  uploadDocument(): void {
+    if (!this.selectedDocument) {
+      this.errorMessage = 'Por favor selecciona un documento primero';
+      return;
+    }
+
+    this.isUploadingDocument = true;
+    this.clearMessages();
+    
+    console.log('📤 Iniciando carga de documento (Organization)...');
+    
+    this.verificationService.uploadSupportDocument(this.selectedDocument).subscribe({
+      next: (response) => {
+        this.successMessage = response.message || '¡Documento subido exitosamente! Tu organización ha sido verificada.';
+        this.isDocumentVerified = true;
+        this.selectedDocument = null;
+        this.documentPreview = null;
+        this.isUploadingDocument = false;
+        
+        // Actualizar el estado en el AuthService
+        this.checkVerificationStatus();
+        
+        console.log('✅ Documento verificado exitosamente (Organization)');
+      },
+      error: (error) => {
+        this.isUploadingDocument = false;
+        const status = error.status;
+        const message = error.error?.message;
+        
+        this.errorMessage = this.verificationService.getErrorMessage(status, message);
+        
+        console.error('❌ Error al subir documento (Organization):', error);
+      }
+    });
   }
 }


### PR DESCRIPTION
## Descripción
Se implementó la interfaz de usuario para la verificación de cuenta de organizaciones mediante carga de documento legal. Se reutilizó el servicio `VerificationService` creado , que maneja la comunicación con el endpoint backend `/auth/update-support-id`. Incluye validaciones del lado del cliente (formato JPG/PNG/PDF, tamaño máximo 5MB), preview de documentos, y manejo de estados visuales. La organización sin verificar ve una sección amarilla para subir su documento legal (RUC, certificado de constitución, registro de ONG, etc.), y después de la verificación exitosa se muestra un badge verde. Se agregó lógica para revisar tanto `user.isDocumentVerified` como `profile.isVerified` para determinar correctamente el estado de verificación.

### Fixes #47
### screenshot
<img width="1022" height="274" alt="image" src="https://github.com/user-attachments/assets/d547ac21-5325-42d6-9227-3edb3e552325" />
<img width="1017" height="205" alt="image" src="https://github.com/user-attachments/assets/bb7852e7-0f84-48f7-8816-d7aa74d08a2b" />
