### PR TITLE
Cambio de "Donaciones Disponibles" a "Donaciones Recibidas" con Filtros

### DIFF
--- a/frontend/src/app/core/services/donation.service.ts
+++ b/frontend/src/app/core/services/donation.service.ts
@@ -261,6 +261,25 @@ export class DonationService {
   }
 
   /**
+   * Obtener donaciones donde el usuario autenticado es beneficiario (organización)
+   */
+  getMyDonationsAsBeneficiary(): Observable<Donation[]> {
+    this.loadingSubject.next(true);
+    const headers = { 'X-No-Cache': 'true' };
+    return this.http.get<any>(`${this.apiUrl}/me/beneficiary`, { headers }).pipe(
+      map(raw => this.normalizeGenericArray<Donation>(raw)),
+      tap(donations => {
+        this.loadingSubject.next(false);
+      }),
+      catchError(error => {
+        this.loadingSubject.next(false);
+        console.error('Error al obtener donaciones como beneficiario:', error);
+        return throwError(() => error);
+      })
+    );
+  }
+
+  /**
    * Obtener una donación por ID
    */
   getDonationById(id: number, bypassCache: boolean = false): Observable<Donation> {

--- a/frontend/src/app/features/organization/dashboard/organization-dashboard.component.html
+++ b/frontend/src/app/features/organization/dashboard/organization-dashboard.component.html
@@ -160,9 +160,9 @@
             [attr.aria-controls]="'donaciones-disponibles-panel'">
             <div class="flex items-center">
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
               </svg>
-              Donaciones Disponibles
+              Donaciones Recibidas
             </div>
           </button>
 
@@ -317,133 +317,221 @@
         </ng-template>
       </div>
 
-  <!-- Tab: Donaciones Disponibles -->
+  <!-- Tab: Donaciones Disponibles (Donaciones Recibidas) -->
   <div *ngIf="activeTab === 'donaciones-disponibles'" class="animate-fade-in">
-          <div class="mb-6 flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-            <div class="flex items-center">
-              <h2 class="text-2xl font-bold text-gray-900 mb-2 mr-4">Donaciones Disponibles</h2>
-            </div>
-            <div class="flex items-center gap-3">
-              <button
-                (click)="onSearchDonations()"
-                type="button"
-                class="inline-flex items-center justify-center px-4 py-2 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 transition-all duration-300 shadow-sm hover:shadow-md focus-ring">
-                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-                </svg>
-                Búsqueda Avanzada
-              </button>
-            </div>
-          </div>
+    <div class="mb-6 flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+      <div class="flex items-center">
+        <h2 class="text-2xl font-bold text-gray-900 mb-2 mr-4">Donaciones Recibidas</h2>
+      </div>
+      <div class="flex items-center gap-3">
+        <span class="text-sm text-gray-500">{{ filteredReceivedDonations.length }} / {{ receivedDonations.length }} {{ receivedDonations.length === 1 ? 'donación' : 'donaciones' }}</span>
+        <button 
+          (click)="toggleFiltersReceived()"
+          class="inline-flex items-center px-4 py-2 bg-gray-100 text-gray-700 font-medium rounded-lg hover:bg-gray-200 transition-colors shadow-sm focus-ring">
+          <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path *ngIf="!showFiltersReceived" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+            <path *ngIf="showFiltersReceived" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/>
+          </svg>
+          {{ showFiltersReceived ? 'Ocultar Filtros' : 'Mostrar Filtros' }}
+        </button>
+      </div>
+    </div>
 
-        <!-- Loading Spinner -->
-        <div *ngIf="loadingAvailableDonations" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <div *ngFor="let item of [1,2,3,4,5,6]" class="bg-white rounded-lg shadow-md overflow-hidden skeleton-shimmer border border-gray-200">
-            <div class="h-32 bg-gray-200"></div>
-            <div class="p-5">
-              <div class="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
-              <div class="h-3 bg-gray-200 rounded w-full mb-4"></div>
-              <div class="h-8 bg-gray-200 rounded w-full"></div>
-            </div>
-          </div>
-        </div>
-
-      <!-- Grid de Cards de Donaciones Disponibles -->
-    <div *ngIf="!loadingAvailableDonations && filteredAvailableDonations.length > 0" 
-     class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-   <div *ngFor="let post of filteredAvailableDonations" 
-               class="donation-card bg-white rounded-lg shadow-md overflow-hidden border border-gray-200 cursor-pointer hover:shadow-lg transition-shadow"
-               [attr.aria-label]="'Donación ' + post.title"
-               (click)="viewPost(post.id)"
-               tabindex="0"
-               role="button"
-               (keydown.enter)="viewPost(post.id)"
-               (keydown.space)="viewPost(post.id)">
-            
-            <!-- Header con imagen o placeholder -->
-            <div class="relative h-48 bg-gradient-to-br from-green-400 via-green-500 to-emerald-600 overflow-hidden">
-              <div *ngIf="post.imagePost && post.imagePost.length > 0" class="w-full h-full">
-                <img [src]="post.imagePost[0].image" [alt]="post.title" class="w-full h-full object-cover">
-              </div>
-              <div *ngIf="!post.imagePost || post.imagePost.length === 0" class="absolute inset-0 bg-pattern opacity-10"></div>
-              
-              <!-- Badges -->
-              <div class="absolute top-3 right-3 flex flex-wrap gap-2 max-w-[60%] justify-end">
-                <!-- Tipo de post -->
-                <span *ngIf="post.typePost" 
-                      [class]="'px-3 py-1 rounded-full text-xs font-semibold shadow-lg ' + (post.typePost.type === 'articulos para donar' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800')">
-                  {{ post.typePost.type === 'articulos para donar' ? 'Donación' : post.typePost.type }}
-                </span>
-                <!-- Etiquetas (tags) del post -->
-                <span *ngFor="let postTag of post.tags?.slice(0, 2)" 
-                      class="px-3 py-1 rounded-full text-xs font-semibold shadow-lg bg-indigo-100 text-indigo-800">
-                  {{ postTag.tag.tag }}
-                </span>
-                <!-- Badge de disponibilidad -->
-                <span class="px-3 py-1 rounded-full text-xs font-semibold shadow-lg bg-green-100 text-green-800">
-                  Disponible
-                </span>
-              </div>
-            </div>
-
-            <!-- Contenido de la card -->
-            <div class="p-5">
-              <!-- Título -->
-              <h3 class="text-lg font-bold text-gray-900 mb-2 line-clamp-1">
-                {{ post.title }}
-              </h3>
-
-              <!-- Descripción -->
-              <p class="text-sm text-gray-600 mb-3 line-clamp-2">
-                {{ post.message }}
-              </p>
-
-              <!-- Información adicional -->
-              <div class="space-y-2 mb-4">
-                <div class="flex items-center text-xs text-gray-500">
-                  <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
-                  </svg>
-                  <span class="truncate">Por: {{ post.user.username }}</span>
-                </div>
-                <div class="flex items-center text-xs text-gray-500">
-                  <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-                  </svg>
-                  <span>Publicado el {{ formatDate(post.createdAt) }}</span>
-                </div>
-                <div class="flex items-center text-xs text-gray-500">
-                  <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/>
-                  </svg>
-                  <span>Usado - Excelente</span>
-                </div>
-              </div>
-
-              <!-- Botón de acción -->
-              <button 
-                (click)="requestAvailableDonation(post); $event.stopPropagation()"
-                class="w-full bg-green-600 text-white px-4 py-2 rounded-lg font-medium text-sm hover:bg-green-700 transition-all duration-200 flex items-center justify-center focus-ring btn-ripple">
-                Solicitar
-              </button>
-            </div>
+    <!-- Panel de Filtros -->
+    <div *ngIf="showFiltersReceived" class="mb-6 bg-white border border-gray-200 rounded-lg p-4 shadow-sm animate-fade-in">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
+        <!-- Búsqueda -->
+        <div class="flex flex-col">
+          <label class="text-xs font-semibold text-gray-600 mb-1">Buscar</label>
+          <div class="relative">
+            <input [(ngModel)]="filters.search" (ngModelChange)="applyFiltersForReceived()" type="text" placeholder="Título, lugar, artículo..." class="w-full rounded-md border-gray-300 focus:border-green-500 focus:ring-green-500 text-sm pr-10" />
+            <svg class="w-4 h-4 text-gray-400 absolute right-2 top-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
           </div>
         </div>
 
-        <!-- Estado: sin donaciones disponibles -->
-        <div *ngIf="!loadingAvailableDonations && filteredAvailableDonations.length === 0" 
-             class="bg-white rounded-lg shadow-sm p-12 text-center">
-          <div class="max-w-md mx-auto">
-            <div class="w-24 h-24 mx-auto mb-6 bg-gray-100 rounded-full flex items-center justify-center">
-              <svg class="w-12 h-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
-              </svg>
-            </div>
-            <h3 class="text-xl font-semibold text-gray-900 mb-2">No hay donaciones disponibles</h3>
-            <p class="text-gray-500 mb-6">No se encontraron donaciones disponibles para solicitar en este momento.</p>
-          </div>
+        <!-- Estado -->
+        <div class="flex flex-col">
+          <label class="text-xs font-semibold text-gray-600 mb-1">Estado</label>
+          <select [(ngModel)]="filters.status" (change)="applyFiltersForReceived()" class="w-full rounded-md border-gray-300 focus:border-green-500 focus:ring-green-500 text-sm">
+            <option value="all">Todos</option>
+            <option *ngFor="let s of statusOptions" [value]="s">{{ s }}</option>
+          </select>
+        </div>
+
+        <!-- Lugar -->
+        <div class="flex flex-col">
+          <label class="text-xs font-semibold text-gray-600 mb-1">Lugar</label>
+          <select [(ngModel)]="filters.location" (change)="applyFiltersForReceived()" class="w-full rounded-md border-gray-300 focus:border-green-500 focus:ring-green-500 text-sm">
+            <option value="all">Todos</option>
+            <option *ngFor="let l of locationOptions" [value]="l">{{ l }}</option>
+          </select>
+        </div>
+
+        <!-- Artículo -->
+        <div class="flex flex-col">
+          <label class="text-xs font-semibold text-gray-600 mb-1">Artículo</label>
+          <select [(ngModel)]="filters.article" (change)="applyFiltersForReceived()" class="w-full rounded-md border-gray-300 focus:border-green-500 focus:ring-green-500 text-sm">
+            <option value="all">Todos</option>
+            <option *ngFor="let a of articleOptions" [value]="a">{{ a }}</option>
+          </select>
+        </div>
+
+        <!-- Desde -->
+        <div class="flex flex-col">
+          <label class="text-xs font-semibold text-gray-600 mb-1">Desde</label>
+          <input [(ngModel)]="filters.dateFrom" (change)="applyFiltersForReceived()" type="date" class="w-full rounded-md border-gray-300 focus:border-green-500 focus:ring-green-500 text-sm" />
+        </div>
+
+        <!-- Hasta -->
+        <div class="flex flex-col">
+          <label class="text-xs font-semibold text-gray-600 mb-1">Hasta</label>
+          <input [(ngModel)]="filters.dateTo" (change)="applyFiltersForReceived()" type="date" class="w-full rounded-md border-gray-300 focus:border-green-500 focus:ring-green-500 text-sm" />
         </div>
       </div>
+      <div class="mt-3 flex flex-wrap gap-2">
+        <button (click)="clearFiltersForReceived()" class="inline-flex items-center px-3 py-1.5 bg-gray-100 text-gray-700 text-xs font-medium rounded-md hover:bg-gray-200 transition-colors">
+          Limpiar filtros
+          <svg class="w-4 h-4 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- Loading Spinner -->
+    <div *ngIf="loadingAvailableDonations" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div *ngFor="let item of [1,2,3,4,5,6]" class="bg-white rounded-lg shadow-md overflow-hidden skeleton-shimmer border border-gray-200">
+        <div class="h-32 bg-gray-200"></div>
+        <div class="p-5">
+          <div class="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
+          <div class="h-3 bg-gray-200 rounded w-full mb-4"></div>
+          <div class="h-8 bg-gray-200 rounded w-full"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Grid de Cards de Donaciones Recibidas -->
+    <div *ngIf="!loadingAvailableDonations && pagedDonations.length > 0" 
+         class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div *ngFor="let donation of pagedDonations" 
+           class="donation-card bg-white rounded-lg shadow-md overflow-hidden border border-gray-200"
+           [attr.aria-label]="'Donación ' + donation.post.title + ', estado ' + getStatusBadge(donation.statusDonation).text"
+           tabindex="0">
+        
+        <!-- Header con gradiente y badge -->
+        <div class="relative h-32 bg-gradient-to-br from-green-400 via-green-500 to-emerald-600 overflow-hidden">
+          <div class="absolute inset-0 bg-pattern opacity-10"></div>
+          <div class="absolute inset-0 flex items-center justify-center">
+            <svg class="w-16 h-16 text-white opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"></path>
+            </svg>
+          </div>
+          
+          <!-- Badge de estado -->
+          <div class="absolute top-3 right-3">
+            <span [class]="getStatusBadge(donation.statusDonation).class"
+                  class="px-3 py-1 rounded-full text-xs font-semibold shadow-lg">
+              {{ getStatusBadge(donation.statusDonation).text }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Contenido de la card -->
+        <div class="p-5">
+          <!-- Título -->
+          <h3 class="text-lg font-bold text-gray-900 mb-2 line-clamp-1">
+            {{ donation.post.title }}
+          </h3>
+
+          <!-- Descripción de artículos -->
+          <p class="text-sm text-gray-600 mb-3 line-clamp-2">
+            {{ getArticlesSummary(donation.articles) }}
+          </p>
+
+          <!-- Información adicional -->
+          <div class="space-y-2 mb-4">
+            <div class="flex items-center text-xs text-gray-500">
+              <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
+              </svg>
+              <span class="truncate">{{ donation.lugarRecogida }}</span>
+            </div>
+            <div class="flex items-center text-xs text-gray-500">
+              <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+              </svg>
+              <span>{{ formatDate(donation.createdAt) }}</span>
+            </div>
+            <div *ngIf="donation.donator" class="flex items-center text-xs text-gray-500">
+              <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
+              </svg>
+              <span>Donante: {{ donation.donator.username }}</span>
+            </div>
+          </div>
+
+          <!-- Botón Ver Detalle -->
+          <button 
+            (click)="viewDonation(donation.id)"
+            class="w-full bg-green-50 text-green-700 px-4 py-2 rounded-lg font-medium text-sm hover:bg-green-100 transition-all duration-200 flex items-center justify-center focus-ring btn-ripple hover:scale-105"
+            [attr.aria-label]="'Ver detalles de la donación ' + donation.post.title">
+            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+            </svg>
+            Ver Detalle
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Paginación -->
+    <div *ngIf="!loadingAvailableDonations && totalPages > 1" class="mt-6 flex flex-wrap items-center justify-center gap-2">
+      <button (click)="prevPage()" [disabled]="page === 1" class="px-3 py-1.5 text-sm rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-50">Anterior</button>
+      <ng-container *ngFor="let p of pages">
+        <button (click)="goToPage(p)" [class]="page === p ? 'bg-green-600 text-white border-green-600' : 'bg-white text-gray-700 border-gray-300'" class="px-3 py-1.5 text-sm rounded-md border hover:bg-gray-50">{{ p }}</button>
+      </ng-container>
+      <button (click)="nextPage()" [disabled]="page === totalPages" class="px-3 py-1.5 text-sm rounded-md border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 disabled:opacity-50">Siguiente</button>
+    </div>
+
+    <!-- Estado: sin donaciones recibidas -->
+    <div *ngIf="!loadingAvailableDonations && receivedDonations.length === 0" 
+         class="bg-white rounded-lg shadow-sm p-12 text-center">
+      <div class="max-w-md mx-auto">
+        <div class="w-24 h-24 mx-auto mb-6 bg-gray-100 rounded-full flex items-center justify-center">
+          <svg class="w-12 h-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-900 mb-2">No has recibido donaciones aún</h3>
+        <p class="text-gray-500 mb-6">Las donaciones que recibas aparecerán aquí.</p>
+      </div>
+    </div>
+
+    <!-- Estado: sin resultados con filtros -->
+    <div *ngIf="!loadingAvailableDonations && receivedDonations.length > 0 && filteredReceivedDonations.length === 0" 
+         class="bg-white rounded-lg shadow-sm p-12 text-center">
+      <div class="max-w-md mx-auto">
+        <div class="w-24 h-24 mx-auto mb-6 bg-gray-100 rounded-full flex items-center justify-center">
+          <svg class="w-12 h-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4"/>
+          </svg>
+        </div>
+        <h3 class="text-xl font-semibold text-gray-900 mb-2">No hay resultados</h3>
+        <p class="text-gray-500 mb-6">No encontramos donaciones que coincidan con los filtros aplicados.</p>
+        <button (click)="clearFiltersForReceived()"
+                class="inline-flex items-center px-5 py-2 bg-gray-100 text-gray-700 font-medium rounded-lg hover:bg-gray-200 transition-colors">
+          Limpiar filtros
+          <svg class="w-4 h-4 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
 
   <!-- Tab: Mis Donaciones (mantener para compatibilidad, pero no se usa en el nuevo diseño) -->
   <div *ngIf="false" class="animate-fade-in">

--- a/frontend/src/app/features/organization/dashboard/organization-dashboard.component.ts
+++ b/frontend/src/app/features/organization/dashboard/organization-dashboard.component.ts
@@ -37,15 +37,16 @@ export class OrganizationDashboardComponent implements OnInit, OnDestroy {
   loadingDonations = false;
   loadingSolicitudes = false;
   loadingAvailableDonations = false;
+  showFiltersReceived = false; // Control de visibilidad del panel de filtros para donaciones recibidas
   loadingMyNeeds = false;
   errorMessage = '';
 
   // Solicitudes donde soy donador
   solicitudes: Donation[] = [];
   
-  // Donaciones disponibles para solicitar (posts de tipo "articulos para donar")
-  availableDonations: Post[] = [];
-  filteredAvailableDonations: Post[] = [];
+  // Donaciones recibidas (donde la organización es beneficiaria)
+  receivedDonations: Donation[] = [];
+  filteredReceivedDonations: Donation[] = [];
   
   // Mis necesidades publicadas (posts de tipo "solicitud de donacion")
   myNeeds: Post[] = [];
@@ -147,7 +148,7 @@ export class OrganizationDashboardComponent implements OnInit, OnDestroy {
 
     // Suscribirse a cambios de pestaña
     this.activeTab$.pipe(takeUntil(this.destroy$)).subscribe(tab => {
-      if (tab === 'donaciones-disponibles' && this.availableDonations.length === 0) {
+      if (tab === 'donaciones-disponibles' && this.receivedDonations.length === 0) {
         this.loadAvailableDonations();
       } else if (tab === 'mis-necesidades' && this.myNeeds.length === 0) {
         this.loadMyNeeds();
@@ -341,30 +342,151 @@ export class OrganizationDashboardComponent implements OnInit, OnDestroy {
   }
   
   /**
-   * Cargar donaciones disponibles para solicitar (posts de tipo "articulos para donar")
+   * Cargar donaciones recibidas (donde la organización es beneficiaria)
    */
   loadAvailableDonations(): void {
     this.loadingAvailableDonations = true;
-    // Cargar todos los posts y filtrar
-    this.postsService.getAllPosts().pipe(takeUntil(this.destroy$)).subscribe({
-      next: (allPosts) => {
-        // Filtrar posts de tipo "articulos para donar" que no sean del usuario actual
-        this.availableDonations = allPosts.filter(post => {
-          const isDonationType = post.typePost?.type === 'articulos para donar';
-          const isNotMine = post.user?.id?.toString() !== this.currentUser?.id?.toString();
-          return isDonationType && isNotMine;
-        });
-        // Ordenar por fecha más reciente
-        this.availableDonations.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-        this.filteredAvailableDonations = [...this.availableDonations];
-        this.loadingAvailableDonations = false;
-      },
-      error: (error) => {
-        console.error('Error al cargar donaciones disponibles:', error);
-        this.loadingAvailableDonations = false;
-        this.toast.error('Error', 'No se pudieron cargar las donaciones disponibles');
+    this.donationService.getMyDonationsAsBeneficiary()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (donations) => {
+          // Ordenar por fecha más reciente
+          this.receivedDonations = donations.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+          // Construir opciones de filtros y aplicar filtros
+          this.buildFilterOptionsForReceived();
+          this.applyFiltersForReceived();
+          this.loadingAvailableDonations = false;
+        },
+        error: (error) => {
+          console.error('Error al cargar donaciones recibidas:', error);
+          this.loadingAvailableDonations = false;
+          this.toast.error('Error', 'No se pudieron cargar las donaciones recibidas');
+        }
+      });
+  }
+
+  /**
+   * Toggle para mostrar/ocultar filtros de donaciones recibidas
+   */
+  toggleFiltersReceived(): void {
+    this.showFiltersReceived = !this.showFiltersReceived;
+  }
+
+  /**
+   * Construir opciones de filtros para donaciones recibidas
+   */
+  private buildFilterOptionsForReceived(): void {
+    const statusSet = new Set<string>();
+    const locationSet = new Set<string>();
+    const articleSet = new Set<string>();
+
+    for (const d of this.receivedDonations) {
+      // Status normalizado a como se muestra en badge
+      const badge = this.getStatusBadge(d.statusDonation);
+      if (badge?.text) statusSet.add(badge.text);
+
+      // Lugares
+      if (d.lugarRecogida) locationSet.add(d.lugarRecogida.trim());
+      if ((d as any).lugarDonacion) {
+        const ld = (d as any).lugarDonacion;
+        if (ld) locationSet.add(String(ld).trim());
       }
+
+      // Artículos
+      if (d.articles && d.articles.length > 0) {
+        for (const a of d.articles) {
+          if (a?.article?.name) articleSet.add(a.article.name.trim());
+        }
+      }
+    }
+
+    this.statusOptions = Array.from(statusSet).sort();
+    this.locationOptions = Array.from(locationSet).sort();
+    this.articleOptions = Array.from(articleSet).sort();
+  }
+
+  /**
+   * Aplicar filtros para donaciones recibidas
+   */
+  applyFiltersForReceived(): void {
+    const search = this.filters.search.trim().toLowerCase();
+    const statusSel = this.filters.status;
+    const locSel = this.filters.location;
+    const artSel = this.filters.article;
+    const from = this.filters.dateFrom ? new Date(this.filters.dateFrom + 'T00:00:00') : null;
+    const to = this.filters.dateTo ? new Date(this.filters.dateTo + 'T23:59:59') : null;
+
+    this.filteredReceivedDonations = this.receivedDonations.filter(d => {
+      // Status
+      if (statusSel !== 'all') {
+        const badge = this.getStatusBadge(d.statusDonation);
+        if (badge.text !== statusSel) return false;
+      }
+
+      // Location
+      if (locSel !== 'all') {
+        const lr = (d.lugarRecogida || '').toString().trim();
+        const ld = ((d as any).lugarDonacion || '').toString().trim();
+        if (lr !== locSel && ld !== locSel) return false;
+      }
+
+      // Article name
+      if (artSel !== 'all') {
+        const names = (d.articles || []).map(a => a?.article?.name?.trim()).filter(Boolean);
+        if (!names.includes(artSel)) return false;
+      }
+
+      // Date range (createdAt)
+      if (from || to) {
+        const created = new Date(d.createdAt);
+        if (from && created < from) return false;
+        if (to && created > to) return false;
+      }
+
+      // Search across title, locations, articles
+      if (search) {
+        const title = (d.post?.title || '').toString().toLowerCase();
+        const lr = (d.lugarRecogida || '').toString().toLowerCase();
+        const ld = ((d as any).lugarDonacion || '').toString().toLowerCase();
+        const arts = (d.articles || []).map(a => a?.article?.name?.toLowerCase()).filter(Boolean).join(' ');
+        const creator = (d.user?.username || '').toLowerCase();
+        const beneficiary = (d.beneficiary?.username || '').toLowerCase();
+        const donator = (d.donator?.username || '').toLowerCase();
+        const haystack = `${title} ${lr} ${ld} ${arts} ${creator} ${beneficiary} ${donator}`;
+        if (!haystack.includes(search)) return false;
+      }
+
+      return true;
     });
+    this.updatePaginationForReceived();
+  }
+
+  /**
+   * Limpiar filtros de donaciones recibidas
+   */
+  clearFiltersForReceived(): void {
+    this.filters = {
+      search: '',
+      status: 'all',
+      location: 'all',
+      article: 'all',
+      dateFrom: null,
+      dateTo: null,
+    };
+    this.page = 1;
+    this.applyFiltersForReceived();
+  }
+
+  /**
+   * Paginación para donaciones recibidas
+   */
+  private updatePaginationForReceived(): void {
+    this.totalPages = Math.max(1, Math.ceil(this.filteredReceivedDonations.length / this.pageSize));
+    if (this.page > this.totalPages) this.page = this.totalPages;
+    if (this.page < 1) this.page = 1;
+    const start = (this.page - 1) * this.pageSize;
+    const end = start + this.pageSize;
+    this.pagedDonations = this.filteredReceivedDonations.slice(start, end);
   }
   
   /**
@@ -615,7 +737,12 @@ export class OrganizationDashboardComponent implements OnInit, OnDestroy {
   goToPage(p: number): void {
     if (p < 1 || p > this.totalPages) return;
     this.page = p;
-    this.updatePagination();
+    // Actualizar paginación según el tab activo
+    if (this.activeTab === 'donaciones-disponibles') {
+      this.updatePaginationForReceived();
+    } else {
+      this.updatePagination();
+    }
     // push page into the url so back/forward preserves it
     this.router.navigate([], {
       relativeTo: this.route,

--- a/frontend/src/app/shared/components/nav/nav.component.html
+++ b/frontend/src/app/shared/components/nav/nav.component.html
@@ -92,7 +92,7 @@
             <svg class="w-4 h-4 md:w-5 md:h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7"/>
             </svg>
-            <span class="ml-1 hidden xl:inline whitespace-nowrap">donaciones Recibidos</span>
+            <span class="ml-1 hidden xl:inline whitespace-nowrap">donaciones Recibidas</span>
             <span class="ml-1 hidden lg:inline xl:hidden text-[10px] whitespace-nowrap">Recibidos</span>
           </button>
           <button


### PR DESCRIPTION
# Descripción

Se modificó el tab "Donaciones Disponibles" del dashboard de organización para que muestre las donaciones recibidas por la organización (donde la organización es beneficiaria) en lugar de posts disponibles para solicitar. Se implementó un sistema de filtros avanzados con funcionalidad de mostrar/ocultar que incluye búsqueda por texto, filtros por estado, lugar, artículo y rango de fechas, los cuales están ocultos por defecto para mejorar la UX. Se actualizó el nombre del tab a "Donaciones Recibidas" y se cambió el icono a una bandeja de entrada (inbox) para reflejar mejor su funcionalidad. Las cards de donaciones ahora muestran información completa incluyendo el donante, estado, artículos y demás detalles relevantes. Se implementó paginación para las donaciones recibidas y se agregaron estados vacíos apropiados para cuando no hay donaciones o cuando no hay resultados después de aplicar filtros.
### fixes #153 
### screenshots
<img width="1730" height="690" alt="image" src="https://github.com/user-attachments/assets/6548e6e7-f08b-4576-b28f-e4e0c01974a3" />

