### PR TITLE
 feat(frontend): render markdown posts with sanitized preview

### DIFF
--- a/frontend/src/app/features/organization/create-donation/create-donation.component.html
+++ b/frontend/src/app/features/organization/create-donation/create-donation.component.html
@@ -23,7 +23,10 @@
     <!-- Información del Post -->
     <div *ngIf="post && !loadingPost" class="mb-6 bg-white shadow-sm rounded-lg p-6">
       <h2 class="text-xl font-semibold text-gray-900 mb-2">{{ post.title }}</h2>
-      <p class="text-gray-600 whitespace-pre-line">{{ post.message }}</p>
+      <app-markdown-view
+        [content]="post.message"
+        cssClass="text-gray-600"
+      ></app-markdown-view>
     </div>
 
     <!-- Mensajes de éxito/error -->

--- a/frontend/src/app/features/organization/create-donation/create-donation.component.ts
+++ b/frontend/src/app/features/organization/create-donation/create-donation.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, FormArray, ReactiveFormsModule, Validators, Abs
 import { Router, ActivatedRoute } from '@angular/router';
 import { DonationService, CreateDonationDTO, ArticleInput, Comment } from '../../../core/services/donation.service';
 import { PostsService, Post, PostArticle } from '../../../core/services/posts.service';
+import { MarkdownViewComponent } from '../../../shared/components/markdown-view/markdown-view.component';
 
 /**
  * Validador personalizado para asegurar que la fecha no sea anterior a hoy
@@ -25,7 +26,7 @@ function minDateValidator(control: AbstractControl): ValidationErrors | null {
 @Component({
   selector: 'app-create-donation',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule],
+  imports: [CommonModule, ReactiveFormsModule, MarkdownViewComponent],
   templateUrl: './create-donation.component.html',
   styleUrls: ['./create-donation.component.scss']
 })

--- a/frontend/src/app/features/organization/dashboard/organization-dashboard.component.html
+++ b/frontend/src/app/features/organization/dashboard/organization-dashboard.component.html
@@ -394,9 +394,11 @@
               </h3>
 
               <!-- Descripción -->
-              <p class="text-sm text-gray-600 mb-3 line-clamp-2">
-                {{ post.message }}
-              </p>
+              <app-markdown-view
+                [content]="post.message"
+                mode="plain"
+                cssClass="text-sm text-gray-600 mb-3 line-clamp-2"
+              ></app-markdown-view>
 
               <!-- Información adicional -->
               <div class="space-y-2 mb-4">

--- a/frontend/src/app/features/organization/dashboard/organization-dashboard.component.ts
+++ b/frontend/src/app/features/organization/dashboard/organization-dashboard.component.ts
@@ -8,13 +8,14 @@ import { AuthService, User } from '../../../core/services/auth.service';
 import { OrganizationProfileService, OrganizationProfile } from '../../../core/services/organization-profile.service';
 import { ToastService } from '../../../core/services/toast.service';
 import { PostsService, Post } from '../../../core/services/posts.service';
+import { MarkdownViewComponent } from '../../../shared/components/markdown-view/markdown-view.component';
 
 type TabType = 'resumen' | 'donaciones-disponibles' | 'mis-solicitudes' | 'mis-necesidades';
 
 @Component({
   selector: 'app-organization-dashboard',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, MarkdownViewComponent],
   templateUrl: './organization-dashboard.component.html',
   styleUrls: ['./organization-dashboard.component.scss']
 })

--- a/frontend/src/app/features/post/details/details.component.html
+++ b/frontend/src/app/features/post/details/details.component.html
@@ -174,7 +174,10 @@
         <!-- Title & Message -->
         <div class="p-3 lg:p-6">
           <h1 class="text-2xl lg:text-3xl font-bold text-gray-900 mb-3 lg:mb-4">{{ post.title }}</h1>
-          <p class="text-sm lg:text-lg text-gray-700 whitespace-pre-line leading-relaxed">{{ post.message }}</p>
+          <app-markdown-view
+            [content]="post.message"
+            cssClass="text-sm lg:text-lg text-gray-700 leading-relaxed"
+          ></app-markdown-view>
         </div>
 
         <!-- Articles (only for type "articulos para donar") -->

--- a/frontend/src/app/features/post/details/details.component.ts
+++ b/frontend/src/app/features/post/details/details.component.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../../../core/services/auth.service';
 import { SidebarComponent } from '../../../shared/components/sidebar/sidebar.component';
 import { ButtonComponent } from '../../../shared/components/button/button.component';
 import { AlertService } from '../../../shared/services/alert.service';
+import { MarkdownViewComponent } from '../../../shared/components/markdown-view/markdown-view.component';
 
 @Pipe({ name: 'safeUrl' })
 export class SafeUrlPipe implements PipeTransform {
@@ -20,7 +21,7 @@ export class SafeUrlPipe implements PipeTransform {
 @Component({
   selector: 'app-details',
   standalone: true,
-  imports: [CommonModule, RouterModule, SidebarComponent, ButtonComponent, SafeUrlPipe],
+  imports: [CommonModule, RouterModule, SidebarComponent, ButtonComponent, SafeUrlPipe, MarkdownViewComponent],
   templateUrl: './details.component.html',
   styleUrl: './details.component.scss'
 })

--- a/frontend/src/app/features/post/edit/edit.component.html
+++ b/frontend/src/app/features/post/edit/edit.component.html
@@ -77,14 +77,15 @@
           <label class="block text-sm font-medium text-gray-700 mb-2">
             Descripción <span class="text-red-500">*</span>
           </label>
-          <textarea 
+          <app-markdown-editor
             [(ngModel)]="message"
             name="message"
-            rows="6"
+            [rows]="6"
             placeholder="Describe tu publicación..."
-            class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent resize-none"
+            [maxLength]="5000"
             [disabled]="isLoading"
-          ></textarea>
+            [showPreview]="true"
+          ></app-markdown-editor>
         </div>
 
         <div *ngIf="existingImages.length > 0" class="space-y-2">

--- a/frontend/src/app/features/post/edit/edit.component.ts
+++ b/frontend/src/app/features/post/edit/edit.component.ts
@@ -8,6 +8,7 @@ import { debounceTime, distinctUntilChanged, switchMap, takeUntil } from 'rxjs/o
 import { PostsService, Tag } from '../../../core/services/posts.service';
 import { SpinnerComponent } from '../../../shared/components/spinner/spinner.component';
 import { ButtonComponent } from '../../../shared/components/button/button.component';
+import { MarkdownEditorComponent } from '../../../shared/components/markdown-editor/markdown-editor.component';
 
 interface ExistingImage {
   id: number;
@@ -25,7 +26,7 @@ export class SafeUrlPipe implements PipeTransform {
 @Component({
   selector: 'app-edit',
   standalone: true,
-  imports: [CommonModule, FormsModule, SpinnerComponent, ButtonComponent, SafeUrlPipe],
+  imports: [CommonModule, FormsModule, SpinnerComponent, ButtonComponent, SafeUrlPipe, MarkdownEditorComponent],
   templateUrl: './edit.component.html',
   styleUrls: ['./edit.component.scss']
 })

--- a/frontend/src/app/features/post/list/list.component.html
+++ b/frontend/src/app/features/post/list/list.component.html
@@ -255,7 +255,10 @@
         <!-- Title & Message -->
         <div class="px-3 lg:px-4 pt-3 lg:pt-4">
           <h3 class="text-lg lg:text-xl font-bold text-gray-900 mb-2">{{ post.title }}</h3>
-          <p class="text-sm lg:text-base text-gray-700 whitespace-pre-line">{{ post.message }}</p>
+          <app-markdown-view
+            [content]="post.message"
+            cssClass="text-sm lg:text-base text-gray-700"
+          ></app-markdown-view>
         </div>
 
         <!-- Articles (for types "articulos para donar" and "solicitud de donacion") -->

--- a/frontend/src/app/features/post/list/list.component.ts
+++ b/frontend/src/app/features/post/list/list.component.ts
@@ -13,6 +13,7 @@ import { SpinnerComponent } from '../../../shared/components/spinner/spinner.com
 import { FormsModule } from '@angular/forms';
 import { ReportService } from '../../../core/services/report.service';
 import { ToastService } from '../../../core/services/toast.service';
+import { MarkdownViewComponent } from '../../../shared/components/markdown-view/markdown-view.component';
 
 @Pipe({ name: 'safeUrl' })
 export class SafeUrlPipe implements PipeTransform {
@@ -32,7 +33,8 @@ export class SafeUrlPipe implements PipeTransform {
     SidebarComponent,
     SafeUrlPipe,
     SpinnerComponent,
-    FormsModule
+    FormsModule,
+    MarkdownViewComponent
   ],
   templateUrl: './list.component.html',
   styleUrl: './list.component.scss'

--- a/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.ts
+++ b/frontend/src/app/shared/components/markdown-editor/markdown-editor.component.ts
@@ -1,7 +1,7 @@
-import { Component, Input, Output, EventEmitter, forwardRef, ViewChild, ElementRef } from '@angular/core';
+import { Component, Input, Output, EventEmitter, forwardRef, ViewChild, ElementRef, SecurityContext } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { DomSanitizer } from '@angular/platform-browser';
 import { marked } from 'marked';
 
 interface FormatButton {
@@ -35,7 +35,7 @@ export class MarkdownEditorComponent implements ControlValueAccessor {
   
   value: string = '';
   showPreviewMode: boolean = false;
-  previewHtml: SafeHtml = '';
+  previewHtml: string = '';
   
   // ControlValueAccessor
   private onChange: (value: string) => void = () => {};
@@ -229,13 +229,12 @@ export class MarkdownEditorComponent implements ControlValueAccessor {
     
     try {
       const html = await marked.parse(this.value);
-      this.previewHtml = this.sanitizer.bypassSecurityTrustHtml(html);
-      console.log('✅ Markdown convertido a HTML');
+      // Se sanitiza en vez de usar bypassSecurityTrustHtml: el preview debe
+      // comportarse igual que la vista pública, que sí recibe texto de terceros
+      this.previewHtml = this.sanitizer.sanitize(SecurityContext.HTML, html) || '';
     } catch (err) {
-      console.error('❌ Error convirtiendo markdown:', err);
-      this.previewHtml = this.sanitizer.bypassSecurityTrustHtml(
-        '<p class="text-red-500">Error al convertir markdown</p>'
-      );
+      console.error('Error convirtiendo markdown:', err);
+      this.previewHtml = '<p class="text-red-500">Error al convertir markdown</p>';
     }
   }
 

--- a/frontend/src/app/shared/components/markdown-view/markdown-view.component.scss
+++ b/frontend/src/app/shared/components/markdown-view/markdown-view.component.scss
@@ -1,0 +1,100 @@
+// Sin esto el host sería inline y rompería line-clamp / márgenes en las tarjetas
+:host {
+  display: block;
+}
+
+// El contenido llega por [innerHTML], así que necesita ::ng-deep para recibir estilos
+.markdown-body {
+  word-break: break-word;
+  overflow-wrap: anywhere;
+
+  ::ng-deep {
+    p {
+      margin: 0 0 0.75rem;
+      &:last-child { margin-bottom: 0; }
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+      font-weight: 600;
+      line-height: 1.3;
+      margin: 1rem 0 0.5rem;
+      &:first-child { margin-top: 0; }
+    }
+
+    h1 { font-size: 1.375rem; }
+    h2 { font-size: 1.25rem; }
+    h3 { font-size: 1.125rem; }
+    h4, h5, h6 { font-size: 1rem; }
+
+    strong, b { font-weight: 700; }
+    em { font-style: italic; }
+    del { text-decoration: line-through; }
+
+    ul, ol {
+      margin: 0 0 0.75rem;
+      padding-left: 1.5rem;
+    }
+
+    ul { list-style: disc; }
+    ol { list-style: decimal; }
+    li { margin-bottom: 0.25rem; }
+
+    a {
+      color: #059669;
+      text-decoration: underline;
+      &:hover { color: #047857; }
+    }
+
+    blockquote {
+      margin: 0 0 0.75rem;
+      padding-left: 0.75rem;
+      border-left: 3px solid #d1d5db;
+      color: #6b7280;
+    }
+
+    code {
+      background-color: #f3f4f6;
+      border-radius: 0.25rem;
+      padding: 0.1rem 0.3rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.875em;
+    }
+
+    pre {
+      background-color: #f3f4f6;
+      border-radius: 0.375rem;
+      padding: 0.75rem;
+      overflow-x: auto;
+      margin: 0 0 0.75rem;
+
+      code {
+        background-color: transparent;
+        padding: 0;
+      }
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 0.375rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0 0 0.75rem;
+    }
+
+    th, td {
+      border: 1px solid #e5e7eb;
+      padding: 0.375rem 0.5rem;
+      text-align: left;
+    }
+
+    hr {
+      border: 0;
+      border-top: 1px solid #e5e7eb;
+      margin: 1rem 0;
+    }
+  }
+}

--- a/frontend/src/app/shared/components/markdown-view/markdown-view.component.ts
+++ b/frontend/src/app/shared/components/markdown-view/markdown-view.component.ts
@@ -1,0 +1,85 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { marked } from 'marked';
+
+/**
+ * Renderiza markdown de forma segura.
+ *
+ * mode="rich"  -> convierte el markdown a HTML (vistas completas: detalle, feed)
+ * mode="plain" -> quita la sintaxis y deja texto plano (tarjetas con line-clamp)
+ *
+ * El HTML se pasa a [innerHTML] como string normal, de modo que Angular lo
+ * sanitiza automáticamente. No se usa bypassSecurityTrustHtml porque el
+ * contenido lo escriben los usuarios.
+ */
+@Component({
+  selector: 'app-markdown-view',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="mode === 'rich'" class="markdown-body" [ngClass]="cssClass" [innerHTML]="renderedHtml"></div>
+    <div *ngIf="mode === 'plain'" [ngClass]="cssClass">{{ plainText }}</div>
+  `,
+  styleUrls: ['./markdown-view.component.scss']
+})
+export class MarkdownViewComponent implements OnChanges {
+  @Input() content: string | null | undefined = '';
+  @Input() mode: 'rich' | 'plain' = 'rich';
+  @Input() cssClass: string = '';
+
+  renderedHtml: string = '';
+  plainText: string = '';
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['content'] || changes['mode']) {
+      this.render();
+    }
+  }
+
+  private render(): void {
+    const source = this.content || '';
+
+    if (this.mode === 'plain') {
+      this.plainText = this.stripMarkdown(source);
+      this.renderedHtml = '';
+      return;
+    }
+
+    this.plainText = '';
+
+    if (!source.trim()) {
+      this.renderedHtml = '';
+      return;
+    }
+
+    try {
+      this.renderedHtml = marked.parse(source, { breaks: true, gfm: true, async: false }) as string;
+    } catch (err) {
+      console.error('Error renderizando markdown:', err);
+      this.renderedHtml = this.escapeHtml(source);
+    }
+  }
+
+  private stripMarkdown(source: string): string {
+    return source
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/`{1,3}([^`]*)`{1,3}/g, '$1')
+      .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+      .replace(/^\s{0,3}>\s?/gm, '')
+      .replace(/^\s*[-*+]\s+/gm, '')
+      .replace(/^\s*\d+\.\s+/gm, '')
+      .replace(/(\*\*|__)(.*?)\1/g, '$2')
+      .replace(/(\*|_)(.*?)\1/g, '$2')
+      .replace(/~~(.*?)~~/g, '$1')
+      .replace(/^\s*([-*_]\s*){3,}$/gm, '')
+      .trim();
+  }
+
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+}

--- a/frontend/src/app/shared/components/user-posts-list/user-posts-list.component.html
+++ b/frontend/src/app/shared/components/user-posts-list/user-posts-list.component.html
@@ -125,7 +125,11 @@
         <h3 class="text-lg font-semibold text-gray-900 mb-2">{{ post.title }}</h3>
 
         <!-- Message -->
-        <p class="text-gray-700 text-sm mb-3 line-clamp-2">{{ post.message }}</p>
+        <app-markdown-view
+          [content]="post.message"
+          mode="plain"
+          cssClass="text-gray-700 text-sm mb-3 line-clamp-2"
+        ></app-markdown-view>
 
         <!-- Tags -->
         <div *ngIf="post.tags && post.tags.length > 0" class="flex flex-wrap gap-1.5 mb-3">

--- a/frontend/src/app/shared/components/user-posts-list/user-posts-list.component.ts
+++ b/frontend/src/app/shared/components/user-posts-list/user-posts-list.component.ts
@@ -8,6 +8,7 @@ import { AuthService } from '../../../core/services/auth.service';
 import { ScrollRestorationService } from '../../../core/services/scroll-restoration.service';
 import { AcknowledgmentFormComponent } from '../acknowledgment-form/acknowledgment-form.component';
 import { AcknowledgmentListComponent } from '../acknowledgment-list/acknowledgment-list.component';
+import { MarkdownViewComponent } from '../markdown-view/markdown-view.component';
 
 @Pipe({ name: 'safeUrl' })
 export class SafeUrlPipe implements PipeTransform {
@@ -20,7 +21,7 @@ export class SafeUrlPipe implements PipeTransform {
 @Component({
   selector: 'app-user-posts-list',
   standalone: true,
-  imports: [CommonModule, RouterModule, SafeUrlPipe, AcknowledgmentFormComponent, AcknowledgmentListComponent],
+  imports: [CommonModule, RouterModule, SafeUrlPipe, AcknowledgmentFormComponent, AcknowledgmentListComponent, MarkdownViewComponent],
   templateUrl: './user-posts-list.component.html',
   styleUrls: ['./user-posts-list.component.scss']
 })


### PR DESCRIPTION
# Descripción

Se mejora la visualización de publicaciones incorporando soporte para renderizado de contenido en Markdown y reforzando la seguridad de la vista previa del editor mediante sanitización del contenido.

# Cambios principales

* Se agrega soporte para renderizar publicaciones en formato Markdown utilizando `markdown-view`.
* Se implementa la sanitización del contenido mostrado en la vista previa del editor para prevenir la renderización de contenido inseguro.
* Se mejora la experiencia de edición y lectura de publicaciones al ofrecer una representación más fiel del contenido Markdown.
