### PR TITLE
feat(notify): add infinite scroll to notification center

### DIFF
--- a/frontend/src/app/core/services/notification.service.ts
+++ b/frontend/src/app/core/services/notification.service.ts
@@ -1,11 +1,20 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { BehaviorSubject, Observable, throwError } from 'rxjs';
-import { tap, catchError } from 'rxjs/operators';
+import { tap, map, catchError, finalize } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { Notify } from '../../shared/model/notification.model';
 import { WebsocketService } from './websocket.service';
 import { NotificationService as SharedNotificationService } from '../../shared/services/notification.service';
+
+export interface NotificationsPage {
+  items: Notify[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+  unreadTotal: number;
+}
 
 @Injectable({
   providedIn: 'root'
@@ -14,9 +23,24 @@ export class NotificationService {
   private baseUrl = environment.apiBackendUrl;
   private notificationsSubject = new BehaviorSubject<Notify[]>([]);
   private unreadCountSubject = new BehaviorSubject<number>(0);
-  
+
+  private currentPage = 1;
+  private readonly pageLimit = 20;
+  private hasMoreValue = false;
+  private loadingMoreValue = false;
+  private total = 0;
+  private activeFilters: any = null;
+
   public notifications$ = this.notificationsSubject.asObservable();
   public unreadCount$ = this.unreadCountSubject.asObservable();
+
+  get hasMore(): boolean {
+    return this.hasMoreValue;
+  }
+
+  get loadingMore(): boolean {
+    return this.loadingMoreValue;
+  }
 
   constructor(
     private http: HttpClient,
@@ -81,19 +105,23 @@ export class NotificationService {
   }
 
   /**
-   * Obtiene todas las notificaciones del usuario autenticado
+   * Obtiene las notificaciones del usuario autenticado con paginación.
+   * Si `page === 1` reemplaza el estado; si es mayor, acumula la siguiente página.
    */
-  getMyNotifications(): Observable<Notify[]> {
+  getMyNotifications(page = 1, limit = this.pageLimit): Observable<Notify[]> {
     const url = `${this.baseUrl}/user-notify/my-notifications`;
+    const params = new HttpParams()
+      .set('page', String(page))
+      .set('limit', String(limit));
 
-    return this.http.get<Notify[]>(url).pipe(
-      tap(raw => {
-        const notifications = this.normalizeNotificationsPayload(raw);
-        this.notificationsSubject.next(notifications);
-        this.updateUnreadCount(notifications);
+    return this.http.get<any>(url, { params }).pipe(
+      map(raw => this.applyNotificationsPage(raw, page)),
+      tap(() => {
+        this.activeFilters = null;
       }),
       catchError((error: HttpErrorResponse) => {
         if (error.status === 404) {
+          this.resetPagination();
           this.notificationsSubject.next([]);
           return throwError(() => ({
             status: 404,
@@ -211,10 +239,10 @@ export class NotificationService {
     type?: number;
     minDate?: string;
     maxDate?: string;
-  }): Observable<Notify[]> {
+  }, page = 1, limit = this.pageLimit): Observable<Notify[]> {
     const url = `${this.baseUrl}/user-notify/my-notifications/filters`;
     
-    const body: any = {};
+    const body: any = { page, limit };
     
     if (filters.search && filters.search.trim() !== '') {
       body.search = filters.search.trim();
@@ -234,15 +262,17 @@ export class NotificationService {
       body.maxDate = maxDateObj.toISOString();
     }
 
-    return this.http.post<Notify[]>(url, body).pipe(
-      tap(raw => {
-        const notifications = this.normalizeNotificationsPayload(raw);
-        this.notificationsSubject.next(notifications);
-        this.updateUnreadCount(notifications);
+    return this.http.post<any>(url, body).pipe(
+      map(raw => this.applyNotificationsPage(raw, page)),
+      tap(() => {
+        this.activeFilters = filters;
       }),
       catchError((error: HttpErrorResponse) => {
         if (error.status === 404) {
-          this.notificationsSubject.next([]);
+          if (page <= 1) {
+            this.resetPagination();
+            this.notificationsSubject.next([]);
+          }
           return throwError(() => ({
             status: 404,
             message: 'No se encontraron notificaciones con los filtros aplicados'
@@ -259,6 +289,97 @@ export class NotificationService {
         return throwError(() => error);
       })
     );
+  }
+
+  /**
+   * Carga la siguiente página de notificaciones (scroll infinito),
+   * respetando los filtros activos si los hay.
+   */
+  loadMoreNotifications(): Observable<Notify[]> | null {
+    if (this.loadingMoreValue || !this.hasMoreValue) return null;
+
+    this.loadingMoreValue = true;
+    const nextPage = this.currentPage + 1;
+
+    let request: Observable<Notify[]>;
+    if (this.activeFilters) {
+      request = this.filterNotifications(this.activeFilters, nextPage, this.pageLimit);
+    } else {
+      request = this.getMyNotifications(nextPage, this.pageLimit);
+    }
+
+    return request.pipe(
+      finalize(() => {
+        this.loadingMoreValue = false;
+      })
+    );
+  }
+
+  /**
+   * Aplica una página de respuesta (envelope o array plano) al estado interno,
+   * acumulando cuando proviene de una página posterior.
+   */
+  private applyNotificationsPage(raw: any, page: number): Notify[] {
+    const paged = this.extractNotificationsPage(raw, page);
+
+    const current = this.notificationsSubject.value;
+    const merged = page > 1 ? this.mergeById(current, paged.items) : paged.items;
+
+    this.notificationsSubject.next(merged);
+    this.currentPage = paged.page;
+    this.total = paged.total;
+    this.hasMoreValue = paged.hasMore;
+
+    if (paged.unreadTotal >= 0) {
+      this.unreadCountSubject.next(paged.unreadTotal);
+    } else if (page <= 1) {
+      this.updateUnreadCount(merged);
+    }
+
+    return merged;
+  }
+
+  /**
+   * Normaliza la respuesta del backend a una página de notificaciones.
+   */
+  private extractNotificationsPage(payload: any, requestedPage: number): NotificationsPage {
+    if (payload && Array.isArray(payload.items)) {
+      const limit = Number(payload.limit) || this.pageLimit;
+      const page = Number(payload.page) || requestedPage;
+      return {
+        items: payload.items as Notify[],
+        total: Number(payload.total) || payload.items.length,
+        page,
+        limit,
+        hasMore: payload.hasMore !== undefined
+          ? !!payload.hasMore
+          : Number(payload.total) > page * limit,
+        unreadTotal: payload.unreadTotal !== undefined ? Number(payload.unreadTotal) : -1,
+      };
+    }
+
+    const items = this.normalizeNotificationsPayload(payload);
+    return {
+      items,
+      total: items.length,
+      page: 1,
+      limit: this.pageLimit,
+      hasMore: false,
+      unreadTotal: -1,
+    };
+  }
+
+  private mergeById(current: Notify[], incoming: Notify[]): Notify[] {
+    const seen = new Set(current.map(n => n.id));
+    const unique = incoming.filter(n => !seen.has(n.id));
+    return [...current, ...unique];
+  }
+
+  private resetPagination(): void {
+    this.currentPage = 1;
+    this.total = 0;
+    this.hasMoreValue = false;
+    this.loadingMoreValue = false;
   }
 
   /**

--- a/frontend/src/app/features/notifications/notifications-center.component.html
+++ b/frontend/src/app/features/notifications/notifications-center.component.html
@@ -354,6 +354,14 @@
           </button>
         </div>
       </div>
+
+      <!-- Scroll infinito: indicador de carga de más notificaciones -->
+      <div *ngIf="hasMore && !isLoading && !hasError" class="py-6 flex justify-center">
+        <div *ngIf="loadingMore" class="flex items-center space-x-2 text-gray-500">
+          <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-green-500"></div>
+          <span class="text-sm">Cargando más notificaciones...</span>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/features/notifications/notifications-center.component.html
+++ b/frontend/src/app/features/notifications/notifications-center.component.html
@@ -186,7 +186,9 @@
     </div>
 
     <!-- Notifications List -->
-    <div class="space-y-3">
+    <div #notificationsScroll
+         (scroll)="onContainerScroll($event)"
+         class="space-y-3 max-h-[70vh] overflow-y-auto pr-1 overscroll-contain">
       <!-- Loading State -->
       <div *ngIf="isLoading" class="bg-white rounded-lg shadow-sm p-8 text-center">
         <div class="flex flex-col items-center justify-center space-y-4">

--- a/frontend/src/app/features/notifications/notifications-center.component.ts
+++ b/frontend/src/app/features/notifications/notifications-center.component.ts
@@ -1,4 +1,4 @@
-import { Component, HostListener, OnInit, OnDestroy } from '@angular/core';
+import { Component, ElementRef, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
@@ -34,6 +34,9 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
   // Modal de confirmación de eliminación
   showDeleteModal = false;
   notificationToDelete: number | null = null;
+
+  // Contenedor scrolleable de la lista de notificaciones
+  @ViewChild('notificationsScroll') notificationsScroll?: ElementRef<HTMLElement>;
 
   // Filtros
   showFilters = false;
@@ -137,20 +140,27 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
     });
   }
 
-  @HostListener('window:scroll', ['$event'])
-  onScroll(): void {
-    this.checkInfiniteScroll();
+  /**
+   * Detecta el scroll dentro del contenedor de la lista
+   */
+  onContainerScroll(event: Event): void {
+    const el = event.target as HTMLElement;
+    this.checkInfiniteScroll(el);
   }
 
   /**
-   * Verifica si el usuario está cerca del final de la página para cargar más
+   * Verifica si el usuario está cerca del final del contenedor para cargar más
    */
-  private checkInfiniteScroll(): void {
+  private checkInfiniteScroll(container?: HTMLElement): void {
     if (!this.hasMore || this.loadingMore || this.isLoading) return;
 
-    const scrollPosition = window.innerHeight + window.scrollY;
-    const documentHeight = document.documentElement.scrollHeight;
-    if (scrollPosition >= documentHeight - 120) {
+    if (!container) {
+      container = this.notificationsScroll?.nativeElement ?? undefined;
+    }
+    if (!container) return;
+
+    const threshold = 120;
+    if (container.scrollHeight - container.scrollTop - container.clientHeight < threshold) {
       this.loadMore();
     }
   }

--- a/frontend/src/app/features/notifications/notifications-center.component.ts
+++ b/frontend/src/app/features/notifications/notifications-center.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, HostListener, OnInit, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { NotificationService } from '../../core/services';
 import { Notify } from '../../shared/model/notification.model'; 
 import { Subject, takeUntil } from 'rxjs';
+import { finalize } from 'rxjs/operators';
 import { FooterComponent } from '../../shared/components/footer/footer.component';
 import { ModalComponent } from '../../shared/components/modal/modal.component';
 
@@ -17,7 +18,6 @@ import { ModalComponent } from '../../shared/components/modal/modal.component';
 })
 export class NotificationsCenterComponent implements OnInit, OnDestroy {
   private destroy$ = new Subject<void>();
-  private isFirstLoad = true;
   private hasLoadedNotifications = false; // Rastrea si alguna vez se cargaron notificaciones
   
   notifications: Notify[] = [];
@@ -52,14 +52,9 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
     this.notificationService.notifications$
       .pipe(takeUntil(this.destroy$))
       .subscribe(nots => {
-  this.notifications = Array.isArray(nots) ? nots : [];
-  this.isLoading = false;
-  this.hasError = false;
-        if (!this.isFirstLoad) {
-          this.notifications = nots;
-          this.isLoading = false;
-          this.hasError = false;
-        }
+        this.notifications = Array.isArray(nots) ? nots : [];
+        this.isLoading = false;
+        this.hasError = false;
       });
 
     this.notificationService.unreadCount$
@@ -75,7 +70,7 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Carga las notificaciones del backend
+   * Carga las notificaciones del backend (primera página)
    */
   loadNotifications(): void {
     this.notifications = [];
@@ -85,20 +80,19 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
     this.notificationService.getMyNotifications()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (notifications: Notify[]) => {
-          this.notifications = notifications;
+        next: () => {
           this.isLoading = false;
-          this.isFirstLoad = false;
           // Marcar que se cargaron notificaciones si hay al menos una
-          if (notifications.length > 0) {
+          if (this.notificationService.getCurrentNotifications().length > 0) {
             this.hasLoadedNotifications = true;
           }
           // Cargar tipos después de que las notificaciones se hayan cargado
           this.loadNotificationTypes();
+          // Auto-cargar más si el contenido aún no llena la ventana
+          this.checkInfiniteScroll();
         },
         error: (error: any) => {
           this.isLoading = false;
-          this.isFirstLoad = false;
           if (error.status === 404) {
             this.notifications = [];
             this.hasError = false;
@@ -116,6 +110,49 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
           }
         }
       });
+  }
+
+  get hasMore(): boolean {
+    return this.notificationService.hasMore;
+  }
+
+  get loadingMore(): boolean {
+    return this.notificationService.loadingMore;
+  }
+
+  /**
+   * Carga la siguiente página cuando el usuario llega al final de la lista
+   */
+  loadMore(): void {
+    const request = this.notificationService.loadMoreNotifications();
+    if (!request) return;
+
+    request.pipe(
+      takeUntil(this.destroy$),
+      finalize(() => this.checkInfiniteScroll())
+    ).subscribe({
+      error: (error) => {
+        console.error('Error al cargar más notificaciones:', error);
+      }
+    });
+  }
+
+  @HostListener('window:scroll', ['$event'])
+  onScroll(): void {
+    this.checkInfiniteScroll();
+  }
+
+  /**
+   * Verifica si el usuario está cerca del final de la página para cargar más
+   */
+  private checkInfiniteScroll(): void {
+    if (!this.hasMore || this.loadingMore || this.isLoading) return;
+
+    const scrollPosition = window.innerHeight + window.scrollY;
+    const documentHeight = document.documentElement.scrollHeight;
+    if (scrollPosition >= documentHeight - 120) {
+      this.loadMore();
+    }
   }
 
   /**
@@ -253,13 +290,13 @@ export class NotificationsCenterComponent implements OnInit, OnDestroy {
     this.notificationService.filterNotifications(filters)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
-        next: (notifications) => {
-          this.notifications = notifications;
+        next: () => {
           this.isLoading = false;
           // Marcar que se cargaron notificaciones si hay al menos una
-          if (notifications.length > 0) {
+          if (this.notificationService.getCurrentNotifications().length > 0) {
             this.hasLoadedNotifications = true;
           }
+          this.checkInfiniteScroll();
         },
         error: (error) => {
           this.isLoading = false;


### PR DESCRIPTION
# Descripción

Se mejora el centro de notificaciones del frontend incorporando soporte para paginación e implementación de scroll infinito, optimizando la carga de información y la experiencia de navegación del usuario.

# Cambios principales

* Se actualiza el servicio de notificaciones para soportar paginación y la carga incremental mediante `loadMoreNotifications`.
* Se implementa scroll infinito en el centro de notificaciones para cargar automáticamente nuevas páginas al llegar al final de la lista.
* Se cambia la lista de notificaciones para utilizar un contenedor con scroll propio en lugar del scroll de la ventana, mejorando la estabilidad y el comportamiento de la interfaz.
* Se optimiza la experiencia de usuario al permitir navegar grandes volúmenes de notificaciones de forma fluida.

### Fixes #166 